### PR TITLE
Add struct tag to allow underscore separated env variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"context"
-	feast "github.com/feast-dev/feast/sdk/go"
-	"github.com/feast-dev/feast/sdk/go/protos/feast/serving"
-	"github.com/feast-dev/feast/sdk/go/protos/feast/types"
-	"github.com/kelseyhightower/envconfig"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
+
+	feast "github.com/feast-dev/feast/sdk/go"
+	"github.com/feast-dev/feast/sdk/go/protos/feast/serving"
+	"github.com/feast-dev/feast/sdk/go/protos/feast/types"
+	"github.com/kelseyhightower/envconfig"
 )
 
 type Config struct {

--- a/main.go
+++ b/main.go
@@ -13,9 +13,9 @@ import (
 )
 
 type Config struct {
-	FeastServingHost string `default:"localhost"`
-	FeastServingPort int    `default:"6566"`
-	ListenPort       string `default:"8080"`
+	FeastServingHost string `default:"localhost" split_words:"true"`
+	FeastServingPort int    `default:"6566" split_words:"true"`
+	ListenPort       string `default:"8080" split_words:"true"`
 }
 
 func main() {


### PR DESCRIPTION
To use environment variables like `LOAD_FEAST_SERVING_HOST` which are separated by underscore, `split_words:"true"` tag is needed in the struct (referenced from [here](https://github.com/kelseyhightower/envconfig#struct-tag-support)).